### PR TITLE
Upgrade to Node.js 22.18 LTS and Vite 7

### DIFF
--- a/docs/upgrade-2025-08.md
+++ b/docs/upgrade-2025-08.md
@@ -16,12 +16,12 @@ This document details the comprehensive upgrade performed on the Three.js playgr
 | svelte | 5.15.0 | 5.38.1 | Latest Svelte 5 with async components support |
 | @sveltejs/kit | 2.15.0 | 2.31.0 | Latest SvelteKit with improved performance |
 | @sveltejs/adapter-vercel | 4.0.5 | 5.9.0 | Enhanced Vercel deployment features |
-| @sveltejs/vite-plugin-svelte | 4.0.4 | 5.1.1 | Compatible with Vite 6 |
+| @sveltejs/vite-plugin-svelte | 4.0.4 | 6.1.2 | Compatible with Vite 7 |
 
 ### Build Tools
 | Package | Previous Version | New Version | Notes |
 |---------|-----------------|-------------|--------|
-| vite | 5.4.11 | 6.3.5 | Vite 7 requires Node.js 22.12+ |
+| vite | 5.4.11 | 7.1.2 | Using Vite 7 with Node.js 22.18 |
 | vitest | 1.6.0 | 2.1.9 | Latest testing framework |
 | typescript | 5.6.2 | 5.9.2 | Latest TypeScript version |
 | svelte-check | 4.1.1 | 4.3.1 | Updated type checking |
@@ -55,7 +55,7 @@ adapter: adapter({
 ### 2. Node.js Engine Requirement (`package.json`)
 ```json
 "engines": {
-  "node": ">=20.0.0"
+  "node": ">=22.12.0"
 }
 ```
 
@@ -78,7 +78,7 @@ Fixed GLSL code block parsing issue in `/src/routes/integer-attributes/+page.sve
 ✅ Vercel deployment configuration optimized
 
 ### Performance Improvements
-- Faster build times with Vite 6
+- Faster build times with Vite 7
 - Improved bundle sizes with latest optimizations
 - Enhanced runtime performance with Node.js 22.x
 
@@ -88,7 +88,7 @@ Fixed GLSL code block parsing issue in `/src/routes/integer-attributes/+page.sve
 - None identified - all updates are backward compatible
 
 ### Known Issues
-- Vite 7 not used due to Node.js version constraint (requires 22.12+, system has 22.11)
+- Node.js upgraded to 22.18.0 (latest LTS)
 - Some unused CSS warnings in build output (non-critical)
 - Prettier warnings for GLSL imports (cosmetic only)
 
@@ -130,7 +130,7 @@ vercel --prod
 
 ## Future Considerations
 
-1. **Vite 7 Upgrade**: When Node.js is updated to 22.12+, upgrade to Vite 7
+1. **✅ Completed**: Node.js upgraded to 22.18.0, Vite 7 installed
 2. **Svelte 5 Features**: Explore new async components and remote functions
 3. **Three.js Updates**: Monitor for Three.js v0.176+ releases
 4. **Performance Monitoring**: Implement Vercel Analytics for production monitoring
@@ -140,4 +140,4 @@ vercel --prod
 - [Svelte 5 Documentation](https://svelte.dev/docs)
 - [SvelteKit Deployment Guide](https://kit.svelte.dev/docs/adapters)
 - [Vercel Adapter Documentation](https://vercel.com/docs/frameworks/sveltekit)
-- [Vite 6 Release Notes](https://vite.dev/blog/announcing-vite6)
+- [Vite 7 Release Notes](https://vite.dev/blog/announcing-vite7)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@sveltejs/adapter-auto": "^3.3.1",
 		"@sveltejs/adapter-vercel": "^5.8.2",
 		"@sveltejs/kit": "^2.29.1",
-		"@sveltejs/vite-plugin-svelte": "^5.1.1",
+		"@sveltejs/vite-plugin-svelte": "^6.1.1",
 		"@tailwindcss/forms": "^0.5.10",
 		"@tailwindcss/typography": "^0.5.16",
 		"@tailwindcss/vite": "^4.0.10",
@@ -49,13 +49,13 @@
 		"svelte-check": "^4.3.1",
 		"tailwindcss": "^4.0.10",
 		"typescript": "^5.7.3",
-		"vite": "^6.3.0",
+		"vite": "^7.0.0",
 		"vite-plugin-glsl": "^1.3.0",
 		"vitest": "^2.1.4"
 	},
 	"type": "module",
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=22.12.0"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,16 +38,16 @@ importers:
         version: 1.54.2
       '@sveltejs/adapter-auto':
         specifier: ^3.3.1
-        version: 3.3.1(@sveltejs/kit@2.31.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))
+        version: 3.3.1(@sveltejs/kit@2.31.0(@sveltejs/vite-plugin-svelte@6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))
       '@sveltejs/adapter-vercel':
         specifier: ^5.8.2
-        version: 5.9.0(@sveltejs/kit@2.31.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))(rollup@4.46.2)
+        version: 5.9.0(@sveltejs/kit@2.31.0(@sveltejs/vite-plugin-svelte@6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))(rollup@4.46.2)
       '@sveltejs/kit':
         specifier: ^2.29.1
-        version: 2.31.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))
+        version: 2.31.0(@sveltejs/vite-plugin-svelte@6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^5.1.1
-        version: 5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))
+        specifier: ^6.1.1
+        version: 6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))
       '@tailwindcss/forms':
         specifier: ^0.5.10
         version: 0.5.10(tailwindcss@4.0.10)
@@ -56,7 +56,7 @@ importers:
         version: 0.5.16(tailwindcss@4.0.10)
       '@tailwindcss/vite':
         specifier: ^4.0.10
-        version: 4.0.10(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))
+        version: 4.0.10(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))
       '@types/polylabel':
         specifier: ^1.1.3
         version: 1.1.3
@@ -97,14 +97,14 @@ importers:
         specifier: ^5.7.3
         version: 5.9.2
       vite:
-        specifier: ^6.3.0
-        version: 6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)
+        specifier: ^7.0.0
+        version: 7.1.2(jiti@2.4.2)(lightningcss@1.29.1)
       vite-plugin-glsl:
         specifier: ^1.3.0
-        version: 1.3.0(rollup@4.46.2)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))
+        version: 1.3.0(rollup@4.46.2)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))
       vitest:
         specifier: ^2.1.4
-        version: 2.1.9(@types/node@22.7.4)(lightningcss@1.29.1)
+        version: 2.1.9(lightningcss@1.29.1)
 
 packages:
 
@@ -798,20 +798,20 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
-    resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.0':
+    resolution: {integrity: sha512-iwQ8Z4ET6ZFSt/gC+tVfcsSBHwsqc6RumSaiLUkAurW3BCpJam65cmHw0oOlDMTO0u+PZi9hilBRYN+LZNHTUQ==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^5.0.0
+      '@sveltejs/vite-plugin-svelte': ^6.0.0-next.0
       svelte: ^5.0.0
-      vite: ^6.0.0
+      vite: ^6.3.0 || ^7.0.0
 
-  '@sveltejs/vite-plugin-svelte@5.1.1':
-    resolution: {integrity: sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+  '@sveltejs/vite-plugin-svelte@6.1.2':
+    resolution: {integrity: sha512-7v+7OkUYelC2dhhYDAgX1qO2LcGscZ18Hi5kKzJQq7tQeXpH215dd0+J/HnX2zM5B3QKcIrTVqCGkZXAy5awYw==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
     peerDependencies:
       svelte: ^5.0.0
-      vite: ^6.0.0
+      vite: ^6.3.0 || ^7.0.0
 
   '@tailwindcss/forms@0.5.10':
     resolution: {integrity: sha512-utI1ONF6uf/pPNO68kmN1b8rEwNXv3czukalo8VtJH8ksIkZXr3Q3VYudZLkCsDd4Wku120uF02hYK25XGPorw==}
@@ -1976,6 +1976,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2145,6 +2150,10 @@ packages:
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2610,19 +2619,19 @@ packages:
       terser:
         optional: true
 
-  vite@6.3.5:
-    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vite@7.1.2:
+    resolution: {integrity: sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@types/node': ^20.19.0 || >=22.12.0
       jiti: '>=1.21.0'
-      less: '*'
+      less: ^4.0.0
       lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -3234,14 +3243,14 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.31.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))':
+  '@sveltejs/adapter-auto@3.3.1(@sveltejs/kit@2.31.0(@sveltejs/vite-plugin-svelte@6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))':
     dependencies:
-      '@sveltejs/kit': 2.31.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))
+      '@sveltejs/kit': 2.31.0(@sveltejs/vite-plugin-svelte@6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-vercel@5.9.0(@sveltejs/kit@2.31.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))(rollup@4.46.2)':
+  '@sveltejs/adapter-vercel@5.9.0(@sveltejs/kit@2.31.0(@sveltejs/vite-plugin-svelte@6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))(rollup@4.46.2)':
     dependencies:
-      '@sveltejs/kit': 2.31.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))
+      '@sveltejs/kit': 2.31.0(@sveltejs/vite-plugin-svelte@6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))
       '@vercel/nft': 0.30.0(rollup@4.46.2)
       esbuild: 0.25.9
     transitivePeerDependencies:
@@ -3249,11 +3258,11 @@ snapshots:
       - rollup
       - supports-color
 
-  '@sveltejs/kit@2.31.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))':
+  '@sveltejs/kit@2.31.0(@sveltejs/vite-plugin-svelte@6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.5(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))
+      '@sveltejs/vite-plugin-svelte': 6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -3266,27 +3275,27 @@ snapshots:
       set-cookie-parser: 2.7.0
       sirv: 3.0.0
       svelte: 5.38.1
-      vite: 6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)
+      vite: 7.1.2(jiti@2.4.2)(lightningcss@1.29.1)
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.0(@sveltejs/vite-plugin-svelte@6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))
+      '@sveltejs/vite-plugin-svelte': 6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))
       debug: 4.4.1
       svelte: 5.38.1
-      vite: 6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)
+      vite: 7.1.2(jiti@2.4.2)(lightningcss@1.29.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))':
+  '@sveltejs/vite-plugin-svelte@6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.0(@sveltejs/vite-plugin-svelte@6.1.2(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)))(svelte@5.38.1)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))
       debug: 4.4.1
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.38.1
-      vite: 6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)
-      vitefu: 1.1.1(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))
+      vite: 7.1.2(jiti@2.4.2)(lightningcss@1.29.1)
+      vitefu: 1.1.1(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -3356,13 +3365,13 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.0.10
 
-  '@tailwindcss/vite@4.0.10(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1))':
+  '@tailwindcss/vite@4.0.10(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1))':
     dependencies:
       '@tailwindcss/node': 4.0.10
       '@tailwindcss/oxide': 4.0.10
       lightningcss: 1.29.1
       tailwindcss: 4.0.10
-      vite: 6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)
+      vite: 7.1.2(jiti@2.4.2)(lightningcss@1.29.1)
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -3513,12 +3522,12 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@9.17.0(jiti@2.4.2))(typescript@5.9.2)
       '@typescript-eslint/utils': 5.62.0(eslint@9.17.0(jiti@2.4.2))(typescript@5.9.2)
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.17.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
-      semver: 7.7.1
+      semver: 7.7.2
       tsutils: 3.21.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
@@ -3530,7 +3539,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.17.0(jiti@2.4.2)
     optionalDependencies:
       typescript: 5.9.2
@@ -3546,7 +3555,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
       '@typescript-eslint/utils': 5.62.0(eslint@9.17.0(jiti@2.4.2))(typescript@5.9.2)
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.17.0(jiti@2.4.2)
       tsutils: 3.21.0(typescript@5.9.2)
     optionalDependencies:
@@ -3560,10 +3569,10 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0
+      debug: 4.4.1
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.7.1
+      semver: 7.7.2
       tsutils: 3.21.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
@@ -3580,7 +3589,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
       eslint: 9.17.0(jiti@2.4.2)
       eslint-scope: 5.1.1
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3616,13 +3625,13 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.11(@types/node@22.7.4)(lightningcss@1.29.1))':
+  '@vitest/mocker@2.1.9(vite@5.4.11(lightningcss@1.29.1))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.7.4)(lightningcss@1.29.1)
+      vite: 5.4.11(lightningcss@1.29.1)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -4525,6 +4534,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nanoid@3.3.11: {}
+
   nanoid@3.3.7: {}
 
   nanoid@3.3.8: {}
@@ -4672,6 +4683,12 @@ snapshots:
   postcss@8.5.3:
     dependencies:
       nanoid: 3.3.8
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5093,13 +5110,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@2.1.9(@types/node@22.7.4)(lightningcss@1.29.1):
+  vite-node@2.1.9(lightningcss@1.29.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.7.4)(lightningcss@1.29.1)
+      vite: 5.4.11(lightningcss@1.29.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -5111,45 +5128,43 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-glsl@1.3.0(rollup@4.46.2)(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)):
+  vite-plugin-glsl@1.3.0(rollup@4.46.2)(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)):
     dependencies:
       '@rollup/pluginutils': 5.1.2(rollup@4.46.2)
-      vite: 6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)
+      vite: 7.1.2(jiti@2.4.2)(lightningcss@1.29.1)
     transitivePeerDependencies:
       - rollup
 
-  vite@5.4.11(@types/node@22.7.4)(lightningcss@1.29.1):
+  vite@5.4.11(lightningcss@1.29.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.3
       rollup: 4.29.1
     optionalDependencies:
-      '@types/node': 22.7.4
       fsevents: 2.3.3
       lightningcss: 1.29.1
 
-  vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1):
+  vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.3
+      postcss: 8.5.6
       rollup: 4.46.2
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 22.7.4
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.29.1
 
-  vitefu@1.1.1(vite@6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)):
+  vitefu@1.1.1(vite@7.1.2(jiti@2.4.2)(lightningcss@1.29.1)):
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.7.4)(jiti@2.4.2)(lightningcss@1.29.1)
+      vite: 7.1.2(jiti@2.4.2)(lightningcss@1.29.1)
 
-  vitest@2.1.9(@types/node@22.7.4)(lightningcss@1.29.1):
+  vitest@2.1.9(lightningcss@1.29.1):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.11(@types/node@22.7.4)(lightningcss@1.29.1))
+      '@vitest/mocker': 2.1.9(vite@5.4.11(lightningcss@1.29.1))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -5165,11 +5180,9 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@22.7.4)(lightningcss@1.29.1)
-      vite-node: 2.1.9(@types/node@22.7.4)(lightningcss@1.29.1)
+      vite: 5.4.11(lightningcss@1.29.1)
+      vite-node: 2.1.9(lightningcss@1.29.1)
       why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.7.4
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
## Summary
Upgraded Node.js to the latest LTS version and Vite to version 7 for improved performance and latest features.

## Changes
- **Node.js**: Upgraded from 22.11.0 to 22.18.0 (latest LTS)
- **Vite**: Upgraded from 6.3.5 to 7.1.2
- **@sveltejs/vite-plugin-svelte**: Upgraded to 6.1.2 for Vite 7 compatibility
- Updated Node.js engine requirement to >=22.12.0
- Updated documentation to reflect the upgrades

## Benefits
- ✨ Faster build times with Vite 7's performance improvements
- 🚀 Latest Node.js LTS for better stability and performance
- 🔧 Full compatibility with Vite 7 ecosystem
- 📦 Improved bundle optimization

## Test plan
- [x] Node.js 22.18.0 installed and verified
- [x] Dependencies install without errors (`pnpm install`)
- [x] Development server runs (`pnpm run dev`)
- [x] Production build succeeds (`pnpm run build`)
- [x] All Three.js examples work correctly

## Notes
This upgrade requires Node.js 22.12+ to be installed. The project has been tested with Node.js 22.18.0.

🤖 Generated with [Claude Code](https://claude.ai/code)